### PR TITLE
feat(post): Add post CRUD feature

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,3 +10,6 @@ services:
       - MYSQL_DATABASE=test
       - MYSQL_ROOT_PASSWORD=test
       - TZ=Asia/Seoul
+    command:
+      - --character-set-server=utf8
+      - --collation-server=utf8_unicode_ci

--- a/src/entities/post.entity.ts
+++ b/src/entities/post.entity.ts
@@ -27,7 +27,7 @@ export class Post {
   @Column({ comment: '내용' })
   content: string;
 
-  @Column()
+  @Column({ default: 0 })
   viewCount: number;
 
   /**

--- a/src/modules/post/dto/create-post.dto.ts
+++ b/src/modules/post/dto/create-post.dto.ts
@@ -1,0 +1,23 @@
+import { IsString, IsOptional, IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreatePostDto {
+  @IsString()
+  @IsNotEmpty()
+  title: string;
+
+  @IsString()
+  @IsNotEmpty()
+  content: string;
+
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  categoryId: number;
+
+  @IsOptional()
+  @IsString({ each: true })
+  tags: string[];
+}

--- a/src/modules/post/dto/update-post.dto.ts
+++ b/src/modules/post/dto/update-post.dto.ts
@@ -1,0 +1,19 @@
+import { IsString, IsOptional, IsNumber } from 'class-validator';
+
+export class UpdatePostDto {
+  @IsOptional()
+  @IsString()
+  title: string;
+
+  @IsOptional()
+  @IsString()
+  content: string;
+
+  @IsOptional()
+  @IsNumber()
+  categoryId: number;
+
+  @IsOptional()
+  @IsString({ each: true })
+  tags: string[];
+}

--- a/src/modules/post/post.controller.ts
+++ b/src/modules/post/post.controller.ts
@@ -1,4 +1,42 @@
-import { Controller } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+} from '@nestjs/common';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
+import { PostService } from './post.service';
 
 @Controller('post')
-export class PostController {}
+export class PostController {
+  constructor(private readonly postService: PostService) {}
+
+  @Get()
+  async getAllPost() {
+    return this.postService.findAll();
+  }
+
+  @Get(':id')
+  async getPost(@Param('id') id: number) {
+    return this.postService.findOne(id);
+  }
+
+  @Patch(':id')
+  async updatePost(@Param('id') id: number, @Body() dto: UpdatePostDto) {
+    return this.postService.findAndUpdate(id, dto);
+  }
+
+  @Post()
+  async addPost(@Body() dto: CreatePostDto) {
+    return this.postService.createPost(dto);
+  }
+
+  @Delete(':id')
+  async deletePost(@Param('id') id: number) {
+    return this.postService.deletePostById(id);
+  }
+}

--- a/src/modules/post/post.module.ts
+++ b/src/modules/post/post.module.ts
@@ -1,9 +1,15 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Post } from '../../entities/post.entity';
+import { Category } from '../../entities/category.entity';
+import { User } from '../../entities/user.entity';
+import { Tag } from '../../entities/tag.entity';
 import { PostController } from './post.controller';
 import { PostService } from './post.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Post, Category, User, Tag])],
   controllers: [PostController],
-  providers: [PostService]
+  providers: [PostService],
 })
 export class PostModule {}

--- a/src/modules/post/post.service.ts
+++ b/src/modules/post/post.service.ts
@@ -1,4 +1,108 @@
-import { Injectable } from '@nestjs/common';
-
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Post } from '../../entities/post.entity';
+import { Category } from '../../entities/category.entity';
+import { User } from '../../entities/user.entity';
+import { Tag } from '../../entities/tag.entity';
+import { CreatePostDto } from './dto/create-post.dto';
+import { UpdatePostDto } from './dto/update-post.dto';
 @Injectable()
-export class PostService {}
+export class PostService {
+  constructor(
+    @InjectRepository(Post)
+    private postRepository: Repository<Post>,
+    @InjectRepository(Category)
+    private categoryRepository: Repository<Category>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
+    @InjectRepository(Tag)
+    private tagRepository: Repository<Tag>,
+  ) {}
+
+  async findOne(id: number): Promise<Post> {
+    const post = await this.postRepository.findOne(id, {
+      relations: ['category', 'tags'],
+    });
+    if (post === undefined) {
+      throw new NotFoundException();
+    }
+    return post;
+  }
+
+  async findAll(): Promise<Post[]> {
+    const posts = await this.postRepository.find({
+      relations: ['category', 'tags'],
+    });
+    return posts;
+  }
+
+  async findAndUpdate(
+    id: number,
+    { title, content, categoryId, tags: dtoTags }: UpdatePostDto,
+  ): Promise<Post> {
+    const post = await this.findOne(id);
+    const category = await this.categoryRepository.findOne(categoryId);
+    if (category === undefined) {
+      throw new NotFoundException(`Category id ${categoryId} is not found`);
+    }
+    const tags = dtoTags
+      ? await Promise.all(dtoTags.map((tag) => this.findOrCreateTag(tag)))
+      : undefined;
+    return await this.postRepository.save({
+      ...post,
+      title,
+      content,
+      category,
+      tags,
+    });
+  }
+
+  async updatePostCount(id: number): Promise<Post> {
+    const post = await this.findOne(id);
+    post.viewCount += 1;
+    return await this.postRepository.save(post);
+  }
+
+  async createPost({
+    title,
+    content,
+    userId,
+    categoryId,
+    tags: dtoTags,
+  }: CreatePostDto): Promise<Post> {
+    const category = await this.categoryRepository.findOne(categoryId);
+    if (category === undefined) {
+      throw new NotFoundException(`Category id ${categoryId} is not found`);
+    }
+    const user = await this.userRepository.findOne(userId);
+    if (user === undefined) {
+      throw new NotFoundException(`User id ${userId} is not found`);
+    }
+    // TODO (jiyoung.lim): Replace to tag provider's method when tag providers is created.
+    const tags = dtoTags
+      ? await Promise.all(dtoTags.map((tag) => this.findOrCreateTag(tag)))
+      : undefined;
+    const post = this.postRepository.create({
+      title,
+      content,
+      user,
+      category,
+      tags,
+    });
+    return await this.postRepository.save(post);
+  }
+
+  async deletePostById(id: number): Promise<void> {
+    await this.postRepository.delete(id);
+  }
+
+  async findOrCreateTag(tagName: string): Promise<Tag> {
+    const tag = await this.tagRepository.findOne({ name: tagName });
+    if (tag !== undefined) {
+      return tag;
+    }
+    const newTag = this.tagRepository.create({ name: tagName });
+    return await this.tagRepository.save(newTag);
+  }
+}


### PR DESCRIPTION
게시글 CRUD 기능을 구현합니다.

### [작업 내용]

#### 1. `@nestjs/swagger` 패키지 설치
`PartialType` 클래스를 사용하기 위해 설치했습니다. [@nestjs/mapped-types](https://github.com/nestjs/mapped-types) 를 쓰는 방법도 있었는데 추후 `swagger`를 붙이는 것도 고려해 해당 패키지로 선택했습니다.
원래는 `update-post.dto`에 `PartialType` 클래스를 사용하기 위해 설치했는데 테스트를 해보니 원하던 퍼포먼스가 나오지 않더라구요 `class-validator` 랑 합이 잘 안맞나 싶기도 하고...그래서 들어내고 재작성했습니다. 


#### 2. 게시글 CRUD 기능 구현
좋아요 기능은 생각보다 좀 시간이 걸릴 것 같아 우선 좋아요 기능을 제외한 나머지 기능만 작업했습니다😢
카테고리와 태그를 조회 및 수정하는 기능은 일단 임시로 만들었고, 아마 해당 프로바이더가 완성되면 그쪽에서 불러와 사용하지 않을까 싶습니다. (까먹지 말라고 TODO로 적어놨습니다.)

태그 작업에 좀 고민이 많았는데 결론만 설명하자면 사용자가 기존에 등록된 태그를 추가하면 그대로 태그 DB에서 찾아 연결하고, 만약 등록되지 않는 신규 태그를 입력한다면 DB에 태그를 추가한 뒤 게시글과 연결하는 식으로 작업했습니다. 자세한 내용은 `post.service.ts` 98라인을 참고해 주시길 바랍니다. 더 좋은 방법이 있다면 공유해주시면 감사하겠습니다!